### PR TITLE
Added class arg for use with ENCs

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -1,16 +1,22 @@
 class dkms (
   $packages       = $dkms::params::packages,
   $packages_devel = $dkms::params::packages_devel,
-  $apt_release    = $dkms::params::apt_release
+  $apt_release    = $dkms::params::apt_release,
+  $modules        = $dkms::params::modules,
 ) inherits dkms::params {
 
   validate_array($packages, $packages_devel)
   validate_string($apt_release)
+  validate_hash($modules)
 
   class { 'dkms::install':
     packages       => $packages,
     packages_devel => $packages_devel,
     apt_release    => $apt_release,
+  }
+
+  if $modules {
+    ensure_resources('dkms::module', $modules)
   }
 
   contain dkms::install

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -1,5 +1,6 @@
 class dkms::params {
   $apt_release = ''
+  $modules = {}
 
   case $::operatingsystem {
     redhat,centos,scientific,oraclelinux: {


### PR DESCRIPTION
This patch allows an ENC to pass in an argument to init.pp for creating dkms definitions.