### PR TITLE
Change the regex to detect the version on CentOS

### DIFF
--- a/lib/facter/dkmsversion.rb
+++ b/lib/facter/dkmsversion.rb
@@ -11,7 +11,7 @@ Facter.add("dkmsversion") do
   confine :kernel => :linux
   setcode do
     out = Facter::Util::Resolution.exec("dkms --version 2>&1")
-    if out =~/^dkms:\s+(.+)$/
+    if out =~/^dkms:\s*(.+)$/
       $1
     end
   end


### PR DESCRIPTION
`dkms --version` on CentOS 7.6 has no space after the colon:

```
$ lsb_release -a
LSB Version:    :core-4.1-amd64:core-4.1-noarch
Distributor ID: CentOS
Description:    CentOS Linux release 7.6.1810 (Core)
Release:        7.6.1810
Codename:       Core

$ dkms --version
dkms:2.6
```